### PR TITLE
Remove trailing \r at the end of SMS

### DIFF
--- a/src/GSMSimSMS.cpp
+++ b/src/GSMSimSMS.cpp
@@ -133,7 +133,6 @@ bool GSMSimSMS::send(char* number, char* message) {
 	_readSerial();
 	str += _buffer;
 	gsm.print(message);
-	gsm.print("\r");
 	//change delay 100 to readserial
 	//_buffer += _readSerial();
 	_readSerial();


### PR DESCRIPTION
(char)26 of ctrl+Z is terminating the SMS.

Adding a \r is send inside the SMS itself so the message finish with a newline that was not in the original string passed to send function.

I think it's more relevant to remove this line to let the user sending the exact message he needs to.

*This has been tested on my SIM800c.